### PR TITLE
Enable more specific overrides

### DIFF
--- a/skeleton/__init__.py
+++ b/skeleton/__init__.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 
-
+SETTINGS = {}
 try:
-    SETTINGS = settings.SKELETON
+    SETTINGS.update(settings.SKELETON)
 except AttributeError:
-    SETTINGS = {}
+    # No overrides
+    pass


### PR DESCRIPTION
This pattern allows us to override only the specific settings in the SKELETON dict.