### PR TITLE
Use correct variant of default value assignment

### DIFF
--- a/setup-development.sh
+++ b/setup-development.sh
@@ -2,7 +2,7 @@
 
 # The name of the virtual environment can be passed as an optional argument to
 # this script. It defaults to "ve".
-VENV=${1:=ve}
+VENV=${1:-ve}
 
 echo "Ensuring required system libraries are installed. You may be prompted for your password."
 sudo apt-get install python-virtualenv python-dev \


### PR DESCRIPTION
`:=` does not work when no argument is specified, while `:-` works as intended..