### PR TITLE
Feature/webpack tweaks

### DIFF
--- a/build-helpers/webpack/helpers.js
+++ b/build-helpers/webpack/helpers.js
@@ -38,7 +38,7 @@ exports.extractCSS = function(opts) {
             loaders: [
                 {
                     test: /\.s[c|a]ss$/,
-                    loader: ExtractTextPlugin.extract('style', 'css!postcss!sass'),
+                    loader: ExtractTextPlugin.extract('style', 'css?sourceMap!postcss!sass?sourceMap'),
                     include: opts.include
                 }
             ]

--- a/build-helpers/webpack/helpers.js
+++ b/build-helpers/webpack/helpers.js
@@ -52,7 +52,7 @@ exports.setupCSS = function(opts) {
             loaders: [
                 {
                     test: /\.s[c|a]ss$/,
-                    loader: 'style!css!postcss!sass',
+                    loader: 'style!css?sourceMap!postcss!sass?sourceMap',
                     include: opts.include
                 }
             ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 // #############
 // SETUP
 
-const BASE_PROJECT_NAME = 'skeleton'; // @TODO Replace this with your Django project name.
+const BASE_PROJECT_NAME = 'skeleton';
 
 const
     Path = require('path'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ const Argv = require('yargs')
     .argv;
 
 const MotePath = `/mote/projects/${Argv.projectName}/${Argv.projectAspect}`;
-const PublicStaticPath = `/static/${BASE_PROJECT_NAME === Argv.projectName ? BASE_PROJECT_NAME : BASE_PROJECT_NAME + '/' + Argv.projectName + '/static'}/generated_statics/bundles/`;
+const PublicStaticPath = `/static/${BASE_PROJECT_NAME === Argv.projectName ? BASE_PROJECT_NAME : BASE_PROJECT_NAME + '/' + Argv.projectName}/generated_statics/bundles/`;
 
 console.log(PublicStaticPath);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,7 +79,6 @@ const BASE_CONFIG = {
             {
                 test: /\.scss$/,
                 loaders: ['postcss'],
-                exclude: ProjectPaths.src + '/tokens',
                 include: ProjectPaths.src
             }
         ]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 // #############
 // SETUP
 
+const BASE_PROJECT_NAME = 'skeleton'; // @TODO Replace this with your Django project name.
+
 const
     Path = require('path'),
 
@@ -17,26 +19,28 @@ const
 // Set environment variables
 const LifecycleEvent = process.env.npm_lifecycle_event;
 const Argv = require('yargs')
-    .default('projectName', 'skeleton') // @TODO: Change this to your project's actual name.
+    .default('projectName', BASE_PROJECT_NAME)
     .default('projectAspect', 'website')
     .argv;
 
 const MotePath = `/mote/projects/${Argv.projectName}/${Argv.projectAspect}`;
-const DjangoStaticDir = `/${Argv.projectName}/static/${Argv.projectName}/`;
-const PublicStaticPath = `/static/${Argv.projectName}/generated_statics/bundles/`;
+const DjangoStaticDir = `/${BASE_PROJECT_NAME}/static/${BASE_PROJECT_NAME}/`;
+const PublicStaticPath = `/static/${BASE_PROJECT_NAME === Argv.projectName ? BASE_PROJECT_NAME : BASE_PROJECT_NAME + '/' + Argv.projectName + '/static'}/generated_statics/bundles/`;
+
+console.log(PublicStaticPath);
 
 const ProjectPaths = {
     root: Path.join(__dirname, MotePath),
     src: Path.join(__dirname, MotePath + '/src'),
-    dist: Path.join(__dirname, DjangoStaticDir + '/generated_statics/bundles')
+    dist: Path.join(__dirname, `${BASE_PROJECT_NAME}${PublicStaticPath}`)
 };
 
 function filenamePattern(prefix, ext) {
     return `${prefix}.[name].[chunkhash].${ext}`;
 }
 
-function bundlenamePattern(project, aspect) {
-    return `./${project}-bundlemap-${aspect}.json`;
+function bundlenamePattern(prefix) {
+    return `./${prefix}-bundlemap.json`;
 }
 
 
@@ -50,7 +54,7 @@ const BASE_CONFIG = {
     },
     output: {
         path: ProjectPaths.dist,
-        filename: filenamePattern(Argv.projectName, 'js'),
+        filename: filenamePattern(`${Argv.projectName}-${Argv.projectAspect}`, 'js'),
         publicPath: PublicStaticPath
     },
     resolve: {
@@ -127,7 +131,7 @@ function configBuilder(process, config) {
                 }),
                 Helpers.globSass(),
                 Helpers.extractCSS({
-                    filename: filenamePattern(Argv.projectName, 'css'),
+                    filename: filenamePattern(`${Argv.projectName}-${Argv.projectAspect}`, 'css'),
                     include: [
                         Path.join(__dirname, MotePath + '/src/styles.scss')
                     ],
@@ -136,7 +140,7 @@ function configBuilder(process, config) {
                 Helpers.minify(),
                 Helpers.trackBundles({
                     path: ProjectPaths.dist,
-                    filename: bundlenamePattern(Argv.projectName, Argv.projectAspect)
+                    filename: bundlenamePattern(`${Argv.projectName}-${Argv.projectAspect}`)
                 })
             );
             break;
@@ -187,10 +191,6 @@ function configBuilder(process, config) {
                     include: [
                         Path.join(__dirname, MotePath + '/src', 'styles.scss')
                     ]
-                }),
-                Helpers.trackBundles({
-                    path: ProjectPaths.dist,
-                    filename: bundlenamePattern(Argv.projectName, Argv.projectAspect)
                 })
             );
             break;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,8 +26,6 @@ const Argv = require('yargs')
 const MotePath = `/mote/projects/${Argv.projectName}/${Argv.projectAspect}`;
 const PublicStaticPath = `/static/${BASE_PROJECT_NAME === Argv.projectName ? BASE_PROJECT_NAME : BASE_PROJECT_NAME + '/' + Argv.projectName}/generated_statics/bundles/`;
 
-console.log(PublicStaticPath);
-
 const ProjectPaths = {
     root: Path.join(__dirname, MotePath),
     src: Path.join(__dirname, MotePath + '/src'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,6 @@ const Argv = require('yargs')
     .argv;
 
 const MotePath = `/mote/projects/${Argv.projectName}/${Argv.projectAspect}`;
-const DjangoStaticDir = `/${BASE_PROJECT_NAME}/static/${BASE_PROJECT_NAME}/`;
 const PublicStaticPath = `/static/${BASE_PROJECT_NAME === Argv.projectName ? BASE_PROJECT_NAME : BASE_PROJECT_NAME + '/' + Argv.projectName + '/static'}/generated_statics/bundles/`;
 
 console.log(PublicStaticPath);


### PR DESCRIPTION
## Part 1

The webpack config now has a `const BASE_PROJECT_NAME` which ought to reflect the Django app name. 

This is then used in `const PublicStaticPath` to determine whether to emit bundles into: 

1) `skeleton/static/skeleton/generated_statics/bundles` 

-OR-

2) `skeleton/static/skeleton/another_project/generated_statics/bundles`

This is done by checking whether `BASE_PROJECT_NAME` is the same as `Argv.projectName`. If it is - I.E: if `-- --projectName="another_project"` is passed through the CLI - the latter is true and 2) is what will be emitted.

---

## Part 2

I have added sourcemap support to the CSS functions in helpers.js. This will aid in debugging and development.

---

## Part 3

I have slightly changed the way in which bundles are named. They will now follow this paradigm:

```
project-aspect.name.hash.ext   --->   skeleton-website.styles.9ba8b91f10e4994f7048.css
```