### PR TITLE
Add formtools to requirements

### DIFF
--- a/project/settings_mobius.py
+++ b/project/settings_mobius.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = (
     "photologue",
     "category",
     "django_comments",
+    "formtools",
     "likes",
     "link",
     "listing",
@@ -32,7 +33,6 @@ INSTALLED_APPS = (
     "post",
     "preferences",
     "sites_groups",
-    "formtools",
 
     # Django apps can be alphabetic
     "django.contrib.admin",

--- a/project/settings_mobius.py
+++ b/project/settings_mobius.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = (
     "post",
     "preferences",
     "sites_groups",
+    "formtools",
 
     # Django apps can be alphabetic
     "django.contrib.admin",

--- a/requirements/mobius.txt
+++ b/requirements/mobius.txt
@@ -15,6 +15,7 @@ Django>=1.9.6,<1.10
 django-category==1.9
 django-contrib-comments==1.7.1
 django-export==1.9
+django-formtools==1.0
 #django-likes==0.2
 django-object-tools==1.9
 django-pagination-fork==1.0.17

--- a/skeleton/tests/requirements/19.txt
+++ b/skeleton/tests/requirements/19.txt
@@ -15,6 +15,7 @@ Django>=1.9.6,<1.10
 django-category==1.9
 django-contrib-comments==1.7.1
 django-export==1.9
+django-formtools==1.0
 #django-likes==0.2
 django-object-tools==1.9
 django-pagination-fork==1.0.17

--- a/skeleton/tests/settings/19.py
+++ b/skeleton/tests/settings/19.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = (
     "post",
     "preferences",
     "sites_groups",
+    "formtools",
 
     # Django apps can be alphabetic
     "django.contrib.admin",

--- a/skeleton/tests/settings/19.py
+++ b/skeleton/tests/settings/19.py
@@ -25,6 +25,7 @@ INSTALLED_APPS = (
     "category",
     "crum",
     "django_comments",
+    "formtools",
     "likes",
     "link",
     "listing",
@@ -36,7 +37,6 @@ INSTALLED_APPS = (
     "post",
     "preferences",
     "sites_groups",
-    "formtools",
 
     # Django apps can be alphabetic
     "django.contrib.admin",


### PR DESCRIPTION
`formtools` was moved out of `django` in version 1.8