### PR TITLE
Removed triple equal rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -51,7 +51,6 @@
         "keyword-spacing": ["error"],
         "space-in-parens": ["error", "never"],
         "no-mixed-spaces-and-tabs": ["error"],
-        "eqeqeq": ["error", "smart"],
         "quote-props": ["error", "consistent", { "keywords": true, "unnecessary": false }]
     }
 }


### PR DESCRIPTION
I'd like to get rid the mandatory `===` rule please. 
Coercion is a very useful tool in JS and I think we should be benefiting from it instead of shunning it just because it happens to be a bit nuanced. 

Reading:
https://davidwalsh.name/fixing-coercion

Reference sheet:
http://getify.github.io/coercions-grid/




